### PR TITLE
[FT006] Refactored code to accomodate defaulted Position = Position<int>

### DIFF
--- a/tanks/common/inc/position.h
+++ b/tanks/common/inc/position.h
@@ -7,7 +7,7 @@ namespace common
 // unsigned ints. But for the purpose of making it work with doubles as well, let's make it
 // a template
 template <typename ValueType = size_t>
-class Position final
+class Position_t final
 {
 public:
     // TODO consider using StrongTypes ?
@@ -15,17 +15,17 @@ public:
     using XPos = ValueType;
     using YPos = ValueType;
     // need a default ctor
-    explicit Position(XPos x = {}, YPos y = {})
+    explicit Position_t(XPos x = {}, YPos y = {})
         : m_x{x}
         , m_y{y}
     {
     }
-    Position(Position const& rhs) = default;
-    Position(Position&& rhs)      = default;
-    Position& operator=(Position const& rhs) = default;
-    Position& operator=(Position&& rhs) = default;
+    Position_t(Position_t const& rhs) = default;
+    Position_t(Position_t&& rhs)      = default;
+    Position_t& operator=(Position_t const& rhs) = default;
+    Position_t& operator=(Position_t&& rhs) = default;
 
-    ~Position()
+    ~Position_t()
     {
     }
 
@@ -53,18 +53,18 @@ public:
         m_x = newX;
         m_y = newY;
     }
-    void reset(Position const& newPos)
+    void reset(Position_t const& newPos)
     {
         reset(newPos.m_x, newPos.m_y);
     }
 
-    Position& moveOnX(XPos howMuch)
+    Position_t& moveOnX(XPos howMuch)
     {
         m_x += howMuch;
         return *this;
     }
 
-    Position& moveOnY(YPos howMuch)
+    Position_t& moveOnY(YPos howMuch)
     {
         m_y += howMuch;
         return *this;
@@ -75,20 +75,22 @@ private:
     YPos m_y;
 };
 
+using Position = Position_t<int>;
+
 template <typename ValueType>
-inline bool operator==(Position<ValueType> const& p1, Position<ValueType> const& p2)
+inline bool operator==(Position_t<ValueType> const& p1, Position_t<ValueType> const& p2)
 {
     return p1.getX() == p2.getX() && p1.getY() == p2.getY();
 }
 
 template <typename ValueType>
-inline bool operator!=(Position<ValueType> const& p1, Position<ValueType> const& p2)
+inline bool operator!=(Position_t<ValueType> const& p1, Position_t<ValueType> const& p2)
 {
     return !(p1 == p2);
 }
 
 template <typename ValueType>
-std::ostream& operator<<(std::ostream& out, Position<ValueType> const& pos)
+std::ostream& operator<<(std::ostream& out, Position_t<ValueType> const& pos)
 {
     out << "(" << pos.getX() << ", " << pos.getY() << ")";
     return out;

--- a/tanks/game/inc/bullet.h
+++ b/tanks/game/inc/bullet.h
@@ -6,7 +6,7 @@
 class Bullet
 {
 public:
-    explicit Bullet(common::Position<int> const& initialPosition = common::Position<int>(),
+    explicit Bullet(common::Position const& initialPosition = common::Position(),
                     eHeading const initialHeading = eHeading::North, common::Speed const = common::Speed{},
                     common::Damage damage = common::Damage{});
 
@@ -18,12 +18,12 @@ public:
 
     Bullet& operator=(Bullet&& rhs) = default;
 
-    common::Position<int> getPosition() const;
+    common::Position getPosition() const;
 
     void move();
 
 private:
-    common::Position<int> m_position;
+    common::Position m_position;
     common::Speed         m_speed;
     common::Damage        m_damage;
     eHeading              m_heading;

--- a/tanks/game/inc/vehicle.h
+++ b/tanks/game/inc/vehicle.h
@@ -9,7 +9,7 @@ using Name = common::Name;
 class Vehicle
 {
 public:
-    using Position = common::Position<int>;
+    using Position = common::Position;
     using XPos = Position::XPos;
     using YPos = Position::YPos;
 

--- a/tanks/game/src/bullet.cpp
+++ b/tanks/game/src/bullet.cpp
@@ -1,6 +1,6 @@
 #include "bullet.h"
 
-Bullet::Bullet(common::Position<int> const& initialPosition, eHeading const initialHeading, common::Speed speed,
+Bullet::Bullet(common::Position const& initialPosition, eHeading const initialHeading, common::Speed speed,
                common::Damage damage)
     : m_position(initialPosition)
     , m_speed(speed)
@@ -9,7 +9,7 @@ Bullet::Bullet(common::Position<int> const& initialPosition, eHeading const init
 {
 }
 
-common::Position<int> Bullet::getPosition() const
+common::Position Bullet::getPosition() const
 {
     return m_position;
 }

--- a/tanks/tests/testcommon/testposition.cpp
+++ b/tanks/tests/testcommon/testposition.cpp
@@ -3,31 +3,31 @@
 
 using namespace common;
 
-using XPos = typename Position<int>::XPos;
-using YPos = typename Position<int>::YPos;
+using XPos = typename Position::XPos;
+using YPos = typename Position::YPos;
 
 TEST(APosition, CanBeDefaultConstructed)
 {
-    Position<int> pos{};
+    Position pos{};
 }
 
 TEST(APosition, HasZeroValuesWhenDefaultConstructed)
 {
-    Position<double> pos{};
-    ASSERT_DOUBLE_EQ(pos.getX(), Position<int>::XPos{});
-    ASSERT_DOUBLE_EQ(pos.getY(), Position<int>::YPos{});
+    Position_t<double> pos{};
+    ASSERT_DOUBLE_EQ(pos.getX(), Position::XPos{});
+    ASSERT_DOUBLE_EQ(pos.getY(), Position::YPos{});
 }
 
 TEST(APosition, CanBeConstructedWithOnlyOneDimension)
 {
-    Position<int> posWithX{XPos{10}};
+    Position posWithX{XPos{10}};
     ASSERT_EQ(posWithX.getX(), 10);
-    ASSERT_EQ(posWithX.getY(), Position<int>::YPos{});
+    ASSERT_EQ(posWithX.getY(), Position::YPos{});
 }
 
 TEST(APosition, CanSetBothItsValues)
 {
-    Position<int> pos{};
+    Position pos{};
 
     pos.setX(XPos{10});
     pos.setY(YPos{15});
@@ -38,13 +38,13 @@ TEST(APosition, CanSetBothItsValues)
 
 TEST(APosition, CanBeResetToAnother)
 {
-    Position<int> original{10, 20};
+    Position original{10, 20};
 
     original.reset(1, 2);
 
-    EXPECT_EQ(original, Position<int>(1, 2));
+    EXPECT_EQ(original, Position(1, 2));
 
-    Position<int> after{3, 4};
+    Position after{3, 4};
     original.reset(after);
 
     EXPECT_EQ(original, after);
@@ -52,8 +52,8 @@ TEST(APosition, CanBeResetToAnother)
 
 TEST(APosition, CanBeDeepCopied)
 {
-    Position<int> original{10, 15};
-    Position<int> copy{original};
+    Position original{10, 15};
+    Position copy{original};
 
     ASSERT_EQ(original, copy);
 
@@ -64,7 +64,7 @@ TEST(APosition, CanBeDeepCopied)
 
 TEST(APosition, PrintsXAndYSeparatedByCommas)
 {
-    Position<int> pos{1, 2};
+    Position pos{1, 2};
 
     std::ostringstream oss{};
     oss << pos;
@@ -75,8 +75,8 @@ TEST(APosition, PrintsXAndYSeparatedByCommas)
 
 TEST(APosition, canIncrementXandY)
 {
-    Position<int> finalPos{11, 9};
-    Position<int> pos{10, 10};
+    Position finalPos{11, 9};
+    Position pos{10, 10};
     pos.moveOnX(1);
     pos.moveOnY(-1);
     ASSERT_EQ(pos, finalPos);

--- a/tanks/tests/testgame/testbullet.cpp
+++ b/tanks/tests/testgame/testbullet.cpp
@@ -6,13 +6,13 @@ class ABullet : public ::testing::Test
 {
 public:
     ABullet()
-        : initialPosition(common::Position<int>(10, 10))
+        : initialPosition(common::Position(10, 10))
         , initialHeading(eHeading::North)
     {
     }
 
     Bullet                b;
-    common::Position<int> initialPosition;
+    common::Position initialPosition;
     eHeading              initialHeading;
 };
 
@@ -23,7 +23,7 @@ TEST_F(ABullet, IsDefaultContructable)
 
 TEST_F(ABullet, HasDefaultPosition)
 {
-    common::Position<int> initialPosition;
+    common::Position initialPosition;
     EXPECT_EQ(b.getPosition(), initialPosition);
 }
 
@@ -45,10 +45,10 @@ TEST_F(ABullet, CanChangePositionWithMoveMethod)
     bSouth.move();
     bWest.move();
 
-    EXPECT_EQ(bNorth.getPosition(), common::Position<int>(initialPosition).moveOnY(-1));
-    EXPECT_EQ(bEast.getPosition(), common::Position<int>(initialPosition).moveOnX(1));
-    EXPECT_EQ(bSouth.getPosition(), common::Position<int>(initialPosition).moveOnY(1));
-    EXPECT_EQ(bWest.getPosition(), common::Position<int>(initialPosition).moveOnX(-1));
+    EXPECT_EQ(bNorth.getPosition(), common::Position(initialPosition).moveOnY(-1));
+    EXPECT_EQ(bEast.getPosition(), common::Position(initialPosition).moveOnX(1));
+    EXPECT_EQ(bSouth.getPosition(), common::Position(initialPosition).moveOnY(1));
+    EXPECT_EQ(bWest.getPosition(), common::Position(initialPosition).moveOnX(-1));
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The problem we what was that Position<int> was polluting the code base.
In case we decided we needed to change to Position<double>
We would have to change everywhere.
This modification allows us to change in one place and be done with it.